### PR TITLE
Add dep to importlib_metadata for Python < 3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 4bafdc6bcfd83ee1e5874607577f7388cd3492cbdb06fc875979c6398ad41ab0
 
 build:
-  number: 0
-  noarch: python
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools_scm
+    - python
+    - setuptools_scm >=1.15
   run:
-    - python >=3.6
+    - importlib_metadata  # [py<38]
+    - python
 
 test:
   imports:


### PR DESCRIPTION
As per: https://github.com/jazzband/inflect/blob/407dfa7e170a562012f37e9bd65c3b50cd3da0cb/setup.cfg#L29-L31

This also implies that this package can no longer be noarch:python.

@conda-forge-admin, please rerender